### PR TITLE
fix sanitize_transient function

### DIFF
--- a/widget.php
+++ b/widget.php
@@ -586,7 +586,7 @@ function gsfcSave(t) {
      */
     public static function sanitize_transient( $name ) {
         if ( 40 < strlen( $name ) )
-            $name = substr( $string, 0, 40 );
+            $name = substr( $name, 0, 40 );
         return $name;
     }
     


### PR DESCRIPTION
input for substr was an undefined $string. Changed this to $name, which is the string being shortened
