### PR TITLE
Still run the_title filters on post titles.

### DIFF
--- a/widget.php
+++ b/widget.php
@@ -490,6 +490,9 @@ class GS_Featured_Content extends WP_Widget {
             $hclass = '';
 		}
 
+		// Act like WP so the_title filters still run
+		$title = apply_filters( 'the_title', $title, get_the_ID() );
+
         $pattern = apply_filters( 'gsfc_post_title_pattern', '<h2%s>%s%s%s</h2>' );
         printf( $pattern, $hclass, $wrap_open, $title, $wrap_close );
     }


### PR DESCRIPTION
The title used by the widget is built out of the title value returned by `the_title_attribute` method.  This is likely to make it easier to truncate the titles.  

The draw back to this is that the titles then never pass through the `the_title` filters which is a problem if the title has any values that should really be entities or that need any type of escaping.  It also causes problems for any other plugins that rely on that filter hook for their own functionality. 

This small change fixes that issue.