### PR TITLE
Update gs-featured-content-widget.php

### DIFF
--- a/gs-featured-content-widget.php
+++ b/gs-featured-content-widget.php
@@ -81,6 +81,9 @@ function gsfc_widgets_init() {
     if ( class_exists( 'Premise_Base' ) && !is_admin() ) {
         return;
     }
+	   if ( ! function_exists( 'genesis_get_option' ) ) {
+		      return;
+	   }
     $gfwa = genesis_get_option( 'gsfc_gfwa' );
     if ( class_exists( 'Genesis_Featured_Widget_Amplified' ) && $gfwa ) {
         unregister_widget( 'Genesis_Featured_Widget_Amplified' );


### PR DESCRIPTION
Additional check for Genesis if switching to parent theme after plugin is already active. http://wpsites.net/best-plugins/bug-fix-genesis-featured-content-widget-fatal-error-call-to-undefined-function-genesis_get_option/
