### PR TITLE
Develop

### DIFF
--- a/gs-featured-content-widget.php
+++ b/gs-featured-content-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: Genesis Sandbox Featured Content Widget
  * Plugin URI: https://wpsmith.net/
  * Description: Based on the Genesis Featured Widget Amplified for additional functionality which allows support for custom post types, taxonomies, and extends the flexibility of the widget via action hooks to allow the elements to be re-positioned or other elements to be added.
- * Version: 1.2.4
+ * Version: 1.2.5
  * Author: Travis Smith
  * Author URI: http://wpsmith.net/
  *

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,9 @@ Well, I bother Nick all the time to change things. He's busy. I'm busy. So, inst
 1. gsfc_form_fields - Add custom fields to widget form
 
 == Changelog ==
+1.2.5 (11/22/2017)
+* Fixed disabled checkboxes. Props mbootsman
+
 1.1.8 (07/18/2014)
 * Fixed post_info/post_meta issue #26, props BenFurfie.
 * Fixed link_title_field issue, #27.

--- a/widget.php
+++ b/widget.php
@@ -1762,7 +1762,7 @@ function gsfcSave(t) {
 							break;
 							
 						case 'checkbox' :
-                            printf( '<input type="checkbox" id="%1$s" name="%2$s" value="1" class="widget-control-save" %3$s />',
+                            printf( '<input type="checkbox" id="%1$s" name="%2$s" value="1" %3$s />',
                                 $obj->get_field_id( $field_id ),
                                 $obj->get_field_name( $field_id ),
                                 checked( 1, $instance[$field_id], false )

--- a/widget.php
+++ b/widget.php
@@ -1762,7 +1762,7 @@ function gsfcSave(t) {
 							break;
 							
 						case 'checkbox' :
-                            printf( '<input type="checkbox" id="%1$s" name="%2$s" value="1" %3$s />',
+                            printf( '<input type="checkbox" id="%1$s" name="%2$s" value="1" onchange="gsfcSave(this)" %3$s />',
                                 $obj->get_field_id( $field_id ),
                                 $obj->get_field_name( $field_id ),
                                 checked( 1, $instance[$field_id], false )


### PR DESCRIPTION
Fixing the failing checkboxes on WordPress 4.9.